### PR TITLE
feat: Check if moz_places and moz_bookmarks tables exist for Mozilla Bookmarks

### DIFF
--- a/bash-script.sh
+++ b/bash-script.sh
@@ -7,7 +7,8 @@ check=`ps -ef|grep firefox|grep -v grep`
 if [ $? -eq 0 ]
 then
 	echo -e "\n"
-	read -rsn1 -p "Firefox is running. If you want any bookmarks you have added since you opened Firefox to be included in this search, close the browser. Otherwise, Press any key to continue . . . : ";
+	echo "Firefox is running. If you want any bookmarks you have added since you opened Firefox to be included in this search, close the browser. "
+	read -rsn1 -p "Otherwise, Press any key to continue . . .  ";
 	echo -e "\n"
 fi
 
@@ -21,7 +22,7 @@ export_chromium_browsers_bookmarks () {
 
         for bookmarks_dir in "${bookmarks_dir[@]}"
         do
-            echo "Directory - '$bookmarks_dir'"
+
             if [ -s "$bookmarks_dir" ]
             then		
 
@@ -61,14 +62,16 @@ then
     
     for bookmarks_dir in "${bookmarks_dir[@]}"
     do
-        echo "Directory - '$bookmarks_dir'"
+
         if [ -s "$bookmarks_dir" ]
         then
-            echo "Bookmarks found"
-	    cp "$bookmarks_dir" new_places.sqlite
-            new_mozilla_sqlite_file=new_places.sqlite
-           
-            sqlite3 "$new_mozilla_sqlite_file" "SELECT json_object('name', IFNULL(moz_places.title , ''), 'url', IFNULL(moz_places.url , '')) FROM moz_places INNER JOIN moz_bookmarks ON moz_places.id = moz_bookmarks.fk;" | jq --arg KEY_WORD "${KEY_WORD,,}" '{"name" : .name, "url" : .url}  | select((.name | ascii_downcase | contains($KEY_WORD)) or (.url | ascii_downcase | contains($KEY_WORD)))' >> bookmarks.md
+	    	cp "$bookmarks_dir" new_places.sqlite
+			
+			if [ $(sqlite3 new_places.sqlite "SELECT count(*) name FROM sqlite_master WHERE type='table' AND name='moz_bookmarks' OR name='moz_places' COLLATE NOCASE;") -eq 2 ]
+			then
+		        sqlite3 new_places.sqlite "SELECT json_object('name', IFNULL(moz_places.title , ''), 'url', IFNULL(moz_places.url , '')) FROM moz_places INNER JOIN moz_bookmarks ON moz_places.id = moz_bookmarks.fk;" | jq --arg KEY_WORD "${KEY_WORD,,}" '{"name" : .name, "url" : .url}  | select((.name | ascii_downcase | contains($KEY_WORD)) or (.url | ascii_downcase | contains($KEY_WORD)))' >> bookmarks.md
+			fi
+			           
         fi 
     done 
   


### PR DESCRIPTION
- Check if tables in places.sqlite exist before fetching bookmarks from the database to prevent sqlite error
- Refactor the "Press any key to continue" prompt
- Use raw file name instead of file stored in variable in sqlite3 commands