### PR TITLE
feat: Add -s flag as alternative to long option --search 

### DIFF
--- a/find-my-bookmark.sh
+++ b/find-my-bookmark.sh
@@ -5,14 +5,14 @@ printf "Welcome to 'find my bookmark'.\n"
 display_help() {
 	echo
 	printf "A script to search for your bookmark in the following browsers: Google Chrome, Mozilla Firefox, Chromium and Brave Browser.\n\n"
-	echo "usage: "$0" [--search=SEARCH] [-dmenu] [--show-all] [-h | --help]"
+	echo "usage: "$0" [--search=SEARCH | -s SEARCH] [-dmenu | -rofi] [--show-all] [-h | --help]"
 	echo
 	echo "where:"
-	echo "    --search=SEARCH | -s SEARCH       SEARCH is the keyword or keywords contained in the name or url of the bookmark you are searching for"	
-	echo "    --show-all                        fetches all bookmarks from all the browsers without filtering on a keyword or keywords"
-	echo "    -dmenu                            shows the bookmarks that match the search in a menu with dmenu"
-	echo "    -rofi                             shows the bookmarks that match the search in a menu with rofi"
-	echo "    -h | --help                       shows this help text and exits"
+	echo "    --search=SEARCH, -s SEARCH       SEARCH is the keyword or keywords contained in the name or url of the bookmark you are searching for"	
+	echo "    -dmenu                           shows the bookmarks that match the search in a menu with dmenu"
+	echo "    -rofi                            shows the bookmarks that match the search in a menu with rofi"
+	echo "    --show-all                       fetches all bookmarks from all the browsers without filtering on a keyword or keywords"
+	echo "    -h, --help                       shows this help text and exits"
 	echo
 	echo "Tip: Enclose 'SEARCH' in quotes especially if it contains space(s)"	
 }
@@ -42,8 +42,7 @@ while test $# -gt 0; do
 		    	export KEY_WORD=$1
 			else
 				unset KEY_WORD
-			exit 1
-			fi
+			fi;
 			shift
 			;;
 		--search*)

--- a/find-my-bookmark.sh
+++ b/find-my-bookmark.sh
@@ -8,11 +8,11 @@ display_help() {
 	echo "usage: "$0" [--search=SEARCH] [-dmenu] [--show-all] [-h | --help]"
 	echo
 	echo "where:"
-	echo "    --search=SEARCH        SEARCH is the keyword or keywords contained in the name or url of the bookmark you are searching for"	
-	echo "    --show-all             fetches all bookmarks from all the browsers without filtering on a keyword or keywords"
-	echo "    -dmenu                 shows the bookmarks that match the search in a menu with dmenu"
-	echo "    -rofi                  shows the bookmarks that match the search in a menu with rofi"
-	echo "    -h | --help            shows this help text and exits"
+	echo "    --search=SEARCH | -s SEARCH       SEARCH is the keyword or keywords contained in the name or url of the bookmark you are searching for"	
+	echo "    --show-all                        fetches all bookmarks from all the browsers without filtering on a keyword or keywords"
+	echo "    -dmenu                            shows the bookmarks that match the search in a menu with dmenu"
+	echo "    -rofi                             shows the bookmarks that match the search in a menu with rofi"
+	echo "    -h | --help                       shows this help text and exits"
 	echo
 	echo "Tip: Enclose 'SEARCH' in quotes especially if it contains space(s)"	
 }
@@ -22,35 +22,45 @@ show_all=false
 
 
 while test $# -gt 0; do
-  case "$1" in
-    -h|--help) display_help; exit 0; ;;
-	-dmenu)
-	  export with_dmenu=true
-	  shift
-      ;;
-	-rofi)
-	  export with_rofi=true
-	  shift
-      ;;
-	--show-all)
-	  export show_all=true
-	  shift
-      ;;
-    --search*)
-	  if [[ $1 == *"="* ]]
-	  # Only tries to get the value of the --search option if $1 != "--search" because string manipulation on $1 
-      # would return "--search" because there is no "=" character
-	  then
-		  export KEY_WORD=`echo ${1#*=}`
-	  else
-		  unset KEY_WORD
-      fi;
-      shift
-      ;;
-    *) echo "Unknown parameter or option passed: '"$1"'"; display_help; exit 0;
-
-      ;;
-  esac
+	case "$1" in
+		-h|--help) display_help; exit 0; ;;
+		-dmenu)
+			export with_dmenu=true
+			shift
+			;;
+		-rofi)
+			export with_rofi=true
+			shift
+			;;
+		--show-all)
+			export show_all=true
+			shift
+			;;
+		-s)
+			shift
+			if test $# -gt 0; then
+		    	export KEY_WORD=$1
+			else
+				unset KEY_WORD
+			exit 1
+			fi
+			shift
+			;;
+		--search*)
+			if [[ $1 == *"="* ]]
+				# Only tries to get the value of the --search option if $1 != "--search" because string manipulation on $1 
+				# would return "--search" because there is no "=" character
+			then
+				export KEY_WORD=`echo ${1#*=}`
+			else
+				unset KEY_WORD
+			fi;
+			shift
+			;;
+		*)
+			echo "Unknown parameter or option passed: '"$1"'"; display_help; exit 0;
+			;;
+	esac
 done
 
 
@@ -77,6 +87,16 @@ else
 fi
 
 echo -e "\n"
+
+
+check=`pgrep firefox`
+if [ $? -eq 0 ]
+then
+	echo -e "\n"
+	echo "Firefox is running. If you want any bookmarks you have added since you opened Firefox to be included in this search, close the browser. "
+	read -rsn1 -p "Otherwise, Press any key to continue . . .  ";
+	echo -e "\n"
+fi
 
 
 > bookmarks.md  # This overwrites the file if it already exists, otherwise, creates a new one and empties it.


### PR DESCRIPTION
- Add short -s option as an alternative method to search for a keyword as opposed to using the long --search option
- Include -s flag in help function
- Remove "optional" in help function because all the options are technically optional since the addition of the --show-all flag
- Add check for firefox being open back because new bookmarks do not show up in search until a newer bookmark is added or browser is closed even though sqlite file is copied
- Remove exit statement when -s flag is misused so that help function would be run before exiting. (fix)
- Use proper matching indentation in flag check block
- Update overall help function

